### PR TITLE
Added a new api call, /api/upload, for generic uploading of songs

### DIFF
--- a/playlist/views.py
+++ b/playlist/views.py
@@ -634,7 +634,6 @@ def api(request, resource=""):
         f.flush()
         temp_filename = f.name
 
-      print("Temp_filename: " + temp_filename)
       if (temp_filename != ""):
         user.userprofile.uploadSong(UploadedFile(temp_filename, filename))
         os.remove(temp_filename)

--- a/playlist/views.py
+++ b/playlist/views.py
@@ -622,11 +622,11 @@ def api(request, resource=""):
     return HttpResponse(json.dumps(d))
 
   if resource == "upload" and request.method == "POST":
+    temp_filename = ""
     try:
       filename = request.POST["filename"]
       # base64 encoded
       filecontents = request.POST["filecontents"]
-      temp_filename = ""
 
       with tempfile.NamedTemporaryFile(mode='wb', delete=False) as f:
         decoded = base64.urlsafe_b64decode(filecontents)
@@ -636,7 +636,6 @@ def api(request, resource=""):
 
       if (temp_filename != ""):
         user.userprofile.uploadSong(UploadedFile(temp_filename, filename))
-        os.remove(temp_filename)
       else:
         raise Exception("Empty filename.")
 
@@ -652,7 +651,12 @@ def api(request, resource=""):
       messages.add_message(request, messages.ERROR, ex)
     else:
       messages.add_message(request, messages.SUCCESS, "Uploaded file successfully!")
+      if (temp_filename != ""):
+        os.remove(temp_filename)
       return HttpResponse(status=200)
+    finally:
+      if (temp_filename != ""):
+        os.remove(temp_filename)
     return HttpResponseBadRequest("\n".join([str(x) for x in messages.get_messages(request)]))
 
   raise Http404


### PR DESCRIPTION
It seems like this works, hope you'll get the bot to upload stuff through this, and remember, check the logs for spam - if uwsgi logs POSTs you're gonna get some big logs.

I tested creating the payload for curl with this handy python3 script, base64thatfile.py song.mp3 > testfile:

```
#!/usr/bin/env python3

import sys
import base64
import urllib.parse
import os.path

if len(sys.argv) == 2:
    with open(sys.argv[1], "rb") as f:
        input = f.read()
        print("filename=" + urllib.parse.quote(os.path.basename(f.name)) + "&filecontents=" + base64.urlsafe_b64encode(input).decode('ascii'), end='', flush=True)
else:
    print("Usage: " + sys.argv[0] + " <file>", file=sys.stderr)
```
I couldn't get the normal unix "base64" utility to produce anything that python wouldn't botch in a way when decoding, that was weird...

Tested like this: `curl -v -d @testfile "http://127.0.0.1:8000/api/upload?userid=<userid>&key=<key>"` where testfile is created with the python script above.